### PR TITLE
[codex] Add final portfolio package

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ StudentBridge is a university capstone web platform that helps international stu
 
 The current implementation uses a static HTML/CSS/JavaScript frontend, Java Servlets running on Apache Tomcat, and a MySQL database accessed through JDBC.
 
+## Final Portfolio
+
+The Spring 2026 final portfolio is available at [`portfolio/README.md`](portfolio/README.md). It includes the final MVP scope, semester journey, QA report, AI/code ownership notes, presentation package, and individual portfolio pages.
+
 ## Current Status
 
 | Area | Status | Notes |
@@ -22,8 +26,8 @@ The current implementation uses a static HTML/CSS/JavaScript frontend, Java Serv
 | Local Tomcat demo | <http://localhost:8080/StudentBridge/> | Use for the midterm live demo after running setup. |
 | Static GitHub Pages demo | <https://capstonedesign-spring2026-ulsancollege.github.io/StudentBridge/> | Verify before using in a presentation. |
 real page link  | https://studentbridge-6jn2.onrender.com
-| Demo video | `[TODO: add demo video link]` | Required backup evidence. |
-| Screenshots | `[TODO: add screenshot folder or issue links]` | Required for sprint packets and brochure QR support. |
+| Demo video | Not available in this repo | Use screenshots and local/Render demo as backup evidence. |
+| Screenshots | [demo-screenshots](demo-screenshots) | Final backup screenshots for homepage, login, register, jobs, employer dashboard, post job, and student profile. |
 
 ## Tech Stack
 
@@ -48,7 +52,7 @@ real page link  | https://studentbridge-6jn2.onrender.com
 
 | Document | Purpose |
 |---|---|
-| [Project Overview](docs/PROJECT_OVERVIEW.md) | Problem, users, solution, MVP scope, and evidence placeholders. |
+| [Project Overview](docs/PROJECT_OVERVIEW.md) | Problem, users, solution, MVP scope, and evidence links. |
 | [Architecture](docs/ARCHITECTURE.md) | Frontend/backend/database structure and key risks. |
 | [Setup Guide](docs/SETUP_GUIDE.md) | Java Servlet, Tomcat, and MySQL setup steps. |
 | [User Stories](docs/USER_STORIES.md) | MVP stories, acceptance criteria, and status. |

--- a/portfolio/01-project-overview/FINAL_MVP_SCOPE.md
+++ b/portfolio/01-project-overview/FINAL_MVP_SCOPE.md
@@ -1,0 +1,65 @@
+# Final MVP Scope
+
+## Final Core User Flow
+
+1. A visitor opens StudentBridge.
+2. The visitor learns the problem and navigates to jobs, login, or registration.
+3. A student searches and filters job listings.
+4. A new user registers as a Student or Employer.
+5. A returning user logs in.
+6. A student can view profile-related information.
+7. An employer can post job information.
+8. A student can apply to a job when profile/CV information is available.
+9. Employers can review applications for their jobs.
+10. Messaging and notifications support follow-up after an application.
+11. Job listings and applications are stored and loaded through MySQL-backed servlet flows when the database is configured.
+12. The team demonstrates known limitations and explains the next technical step.
+
+## Features Included In The Final MVP
+
+| Feature | Status | Evidence |
+|---|---|---|
+| Homepage and main navigation | Included | [../../index.html](../../index.html), [../../frontend/style.css](../../frontend/style.css) |
+| Job search page | Included | [../../frontend/jobsearch.html](../../frontend/jobsearch.html), [../../Backend/JobServlet.java](../../Backend/JobServlet.java) |
+| Registration | Included | [../../frontend/register.html](../../frontend/register.html), [../../Backend/RegisterServlet.java](../../Backend/RegisterServlet.java) |
+| Login/logout | Included | [../../frontend/login.html](../../frontend/login.html), [../../Backend/LoginServlet.java](../../Backend/LoginServlet.java), [../../Backend/LogoutServlet.java](../../Backend/LogoutServlet.java) |
+| Student profile | Included | [../../frontend/student-profile.html](../../frontend/student-profile.html), [../../Backend/StudentProfileServlet.java](../../Backend/StudentProfileServlet.java) |
+| Employer dashboard | Included | [../../frontend/employer-dashboard.html](../../frontend/employer-dashboard.html), [../../Backend/EmployerApplicationsServlet.java](../../Backend/EmployerApplicationsServlet.java) |
+| Employer post-job flow | Included | [../../frontend/post-job.html](../../frontend/post-job.html), [../../Backend/PostJobServlet.java](../../Backend/PostJobServlet.java) |
+| Student application flow | Included | [../../Backend/ApplyServlet.java](../../Backend/ApplyServlet.java), [../../Backend/EmployerApplicationsServlet.java](../../Backend/EmployerApplicationsServlet.java) |
+| Messaging and notifications | Included | [../../Backend/MessageServlet.java](../../Backend/MessageServlet.java), [../../Backend/NotificationServlet.java](../../Backend/NotificationServlet.java) |
+| MySQL schema | Included | [../../database_schema.sql](../../database_schema.sql) |
+| Render deployment support | Included | [../../render.yaml](../../render.yaml), [../../docs/DEPLOY_RENDER.md](../../docs/DEPLOY_RENDER.md) |
+| Demo screenshots | Included | [../../demo-screenshots](../../demo-screenshots) |
+
+## Features That Work Reliably Enough For Demo
+
+- Homepage and visual navigation.
+- Job search UI and job cards.
+- Login and registration screens.
+- Employer dashboard and post-job screens.
+- Database schema documentation.
+- Render and local setup documentation.
+- Demo screenshot backup package.
+
+## Features That Work With Limitations
+
+| Feature | Limitation | Handling |
+|---|---|---|
+| Register/login | Requires correct Tomcat and MySQL environment variables or local database credentials. | Document setup clearly and use demo credentials only. |
+| Job loading | Depends on `jobs` table and seeded data. | Use `database_schema.sql` and `docs/database_jobs.sql`. |
+| Employer job posting | Requires authenticated Employer session and complete schema. | Demo after setup, with screenshots as backup. |
+| Student profile | Application submission requires a student CV link. | Create or seed profile information before demo. |
+| Student applications | Requires logged-in Student session, selected job, and CV link. | Test the student apply path before demo and use screenshots as backup. |
+| Employer application review | Requires logged-in Employer session and jobs owned by that employer. | Seed demo employer/job/application data if needed. |
+| Render deployment | Depends on hosted database environment variables. | Use deployment guide and local fallback. |
+
+## Features Excluded From The Final MVP
+
+| Feature | Reason |
+|---|---|
+| Password hashing | Required before real users, but documented as a security limitation for the class demo. |
+| Resume upload | Useful stretch goal, not required for the core job discovery demo. |
+| Email notifications | Stretch goal after core data flow. |
+| AI job recommendations | Stretch goal after reliable job and application data. |
+| Production-grade authentication and authorization | The project is a capstone MVP, not a production service. |

--- a/portfolio/01-project-overview/PROJECT_SUMMARY.md
+++ b/portfolio/01-project-overview/PROJECT_SUMMARY.md
@@ -1,0 +1,63 @@
+# Project Summary
+
+## Project Identity
+
+| Item | Details |
+|---|---|
+| Team name | StudentBridge |
+| Project name | StudentBridge |
+| Repository | <https://github.com/CapstoneDesign-Spring2026-UlsanCollege/StudentBridge> |
+| Deployed app | <https://studentbridge-6jn2.onrender.com> |
+| Local demo | <http://localhost:8080/StudentBridge/> |
+| Main stack | HTML, CSS, JavaScript, Java Servlets, Apache Tomcat, MySQL, JDBC |
+
+## Team Members
+
+| Student | Main ownership area |
+|---|---|
+| Mezbah Uddin | Backend, database connection, homepage, deployment support |
+| Sami Ul Alim | Job search UI and frontend pages |
+| Ali Mohamad Ashraf | Login, job page support, backend/frontend integration support |
+| Guramg Roman | Documentation, sprint evidence, portfolio organization |
+| Dipesh Chaulagain | Testing, QA support, validation evidence |
+
+## Target User
+
+The primary target user is an international student studying in South Korea who needs a student-friendly part-time job. Secondary users are local employers who want to post jobs for student workers, and university support staff who want a clearer employment resource to recommend.
+
+## Problem
+
+International students often search across scattered job boards, social posts, local signs, and word of mouth. It is hard to know which jobs match student schedules, local language expectations, visa limits, and transportation needs. Employers also lack a focused path to reach nearby international students.
+
+## Value Statement
+
+StudentBridge helps international students find student-friendly part-time jobs and gives local employers a simple way to publish opportunities in one focused platform.
+
+## Final MVP Summary
+
+The final MVP includes a polished homepage, job search page, registration and login, account-type-based flows, student profile support, employer job posting, student application submission, employer application review, notification/messaging support, MySQL-backed data, deployment configuration, and documentation for setup, QA, AI use, and presentation.
+
+## Final Screenshots
+
+Screenshots are stored in [../../demo-screenshots](../../demo-screenshots).
+
+| Screenshot | Purpose |
+|---|---|
+| [01-home.png](../../demo-screenshots/01-home.png) | Homepage and navigation. |
+| [02-login.png](../../demo-screenshots/02-login.png) | Login page. |
+| [03-register-student.png](../../demo-screenshots/03-register-student.png) | Student registration. |
+| [04-jobsearch.png](../../demo-screenshots/04-jobsearch.png) | Job search page. |
+| [05-employer-dashboard.png](../../demo-screenshots/05-employer-dashboard.png) | Employer dashboard. |
+| [06-post-job.png](../../demo-screenshots/06-post-job.png) | Post job form. |
+| [07-student-profile.png](../../demo-screenshots/07-student-profile.png) | Student profile page. |
+
+## Important Portfolio Sections
+
+- [Final MVP Scope](FINAL_MVP_SCOPE.md)
+- [Scope Decisions](SCOPE_DECISIONS.md)
+- [Semester Journey](../02-semester-journey/SEMESTER_JOURNEY.md)
+- [Final MVP Demo](../04-final-product/FINAL_MVP_DEMO.md)
+- [Setup And Run Guide](../04-final-product/SETUP_AND_RUN_GUIDE.md)
+- [QA Report](../05-qa-and-stabilization/QA_REPORT.md)
+- [AI Use Summary](../06-ai-and-code-ownership/AI_USE_SUMMARY.md)
+- [Final Presentation Script](../07-final-presentation/FINAL_PRESENTATION_SCRIPT.md)

--- a/portfolio/01-project-overview/SCOPE_DECISIONS.md
+++ b/portfolio/01-project-overview/SCOPE_DECISIONS.md
@@ -1,0 +1,19 @@
+# Scope Decisions
+
+| Feature or idea | Final status | Why | Evidence |
+|---|---|---|---|
+| Homepage and product story | Included | Needed as the entry point for users and presentation. | [../../index.html](../../index.html) |
+| Responsive shared navigation | Included | Makes the demo feel complete and usable across pages. | [../../frontend/style.css](../../frontend/style.css), [../../frontend/script.js](../../frontend/script.js) |
+| Searchable job list | Included | This is the core student value flow. | [../../frontend/jobsearch.html](../../frontend/jobsearch.html), [../../Backend/JobServlet.java](../../Backend/JobServlet.java) |
+| Student registration | Included | Required for account-based job platform flow. | [../../Backend/RegisterServlet.java](../../Backend/RegisterServlet.java) |
+| Login/logout | Included | Required for role-aware student/employer experience. | [../../Backend/LoginServlet.java](../../Backend/LoginServlet.java), [../../Backend/LogoutServlet.java](../../Backend/LogoutServlet.java) |
+| Student profile | Included | Shows that students can have platform identity beyond a static job page. | [../../frontend/student-profile.html](../../frontend/student-profile.html), [../../Backend/StudentProfileServlet.java](../../Backend/StudentProfileServlet.java) |
+| Employer job posting | Included | Lets the platform support both sides of the marketplace. | [../../frontend/post-job.html](../../frontend/post-job.html), [../../Backend/PostJobServlet.java](../../Backend/PostJobServlet.java) |
+| Employer dashboard | Included | Helps employers see application and job-related activity connected to their account. | [../../frontend/employer-dashboard.html](../../frontend/employer-dashboard.html), [../../Backend/EmployerApplicationsServlet.java](../../Backend/EmployerApplicationsServlet.java) |
+| MySQL-backed job data | Included | Moves the demo beyond static-only job listings. | [../../database_schema.sql](../../database_schema.sql), [../../docs/database_jobs.sql](../../docs/database_jobs.sql) |
+| Render deployment | Working with limitations | Useful for public demo, but local setup remains the backup. | [../../render.yaml](../../render.yaml), [../../docs/DEPLOY_RENDER.md](../../docs/DEPLOY_RENDER.md) |
+| Full application submission | Included | Students can apply to jobs when logged in and profile/CV information is available. | [../../Backend/ApplyServlet.java](../../Backend/ApplyServlet.java), [../../database_schema.sql](../../database_schema.sql) |
+| Password hashing | Cut | Security hardening is required before real users, but not completed for this class MVP. | [../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md](../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md) |
+| Resume upload | Nice Later | Useful but not necessary for the 15-minute final demo. | [../../docs/ROADMAP.md](../../docs/ROADMAP.md) |
+| Email notifications | Nice Later | In-app notifications exist; email delivery can be a future enhancement. | [../../Backend/NotificationServlet.java](../../Backend/NotificationServlet.java) |
+| AI recommendations | Nice Later | Interesting future feature, but not part of the reliable MVP. | [../../docs/ROADMAP.md](../../docs/ROADMAP.md) |

--- a/portfolio/02-semester-journey/SEMESTER_JOURNEY.md
+++ b/portfolio/02-semester-journey/SEMESTER_JOURNEY.md
@@ -1,0 +1,53 @@
+# Semester Journey
+
+StudentBridge developed from a project idea into a working capstone MVP with a frontend, Java Servlet backend, MySQL schema, deployment configuration, demo screenshots, QA notes, and final portfolio package. The semester evidence is linked rather than rewritten so the history stays honest.
+
+## Weekly Files
+
+| Week | File | Existing evidence |
+|---|---|---|
+| 01 | [WEEK_01.md](weekly-sprints/WEEK_01.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week1.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week1.md) |
+| 02 | [WEEK_02.md](weekly-sprints/WEEK_02.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week2.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week2.md) |
+| 03 | [WEEK_03.md](weekly-sprints/WEEK_03.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week3.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week3.md) |
+| 04 | [WEEK_04.md](weekly-sprints/WEEK_04.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week4.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week4.md) |
+| 05 | [WEEK_05.md](weekly-sprints/WEEK_05.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week5.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week5.md) |
+| 06 | [WEEK_06.md](weekly-sprints/WEEK_06.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week6.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week6.md) |
+| 07 | [WEEK_07.md](weekly-sprints/WEEK_07.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week7.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week7.md) |
+| 08 | [WEEK_08.md](weekly-sprints/WEEK_08.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week8.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week8.md) |
+| 09 | [WEEK_09.md](weekly-sprints/WEEK_09.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week9.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week9.md) |
+| 10 | [WEEK_10.md](weekly-sprints/WEEK_10.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week10.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week10.md) |
+| 11 | [WEEK_11.md](weekly-sprints/WEEK_11.md) | [../../docs/Sprint-packets/Weekly Sprint Packet-Week11.md](../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week11.md) |
+| 12 | [WEEK_12.md](weekly-sprints/WEEK_12.md) | Portfolio note and sprint-hardening evidence. |
+| 13 | [WEEK_13.md](weekly-sprints/WEEK_13.md) | Portfolio note and finalization evidence. |
+| 14 | [WEEK_14.md](weekly-sprints/WEEK_14.md) | Portfolio note and finalization evidence. |
+| 15 | [WEEK_15.md](weekly-sprints/WEEK_15.md) | Portfolio note and finalization evidence. |
+| 16 | [WEEK_16.md](weekly-sprints/WEEK_16.md) | Final portfolio and presentation package. |
+
+## Sprint Summaries
+
+- [Sprint 1](sprint-summaries/SPRINT_01.md)
+- [Sprint 2](sprint-summaries/SPRINT_02.md)
+- [Sprint 3](sprint-summaries/SPRINT_03.md)
+- [Sprint 4](sprint-summaries/SPRINT_04.md)
+- [Final Sprint](sprint-summaries/FINAL_SPRINT.md)
+
+## Major Project Changes
+
+| Stage | Change |
+|---|---|
+| Early planning | Defined StudentBridge as a job platform for international students and local employers. |
+| Frontend build | Added homepage, job search page, login, register, and shared styling/navigation. |
+| Backend integration | Added Java Servlets, MySQL connection, registration, login, job loading, and job posting support. |
+| Demo improvement | Added screenshots, setup guide, demo plan, QA notes, and deployment files. |
+| Final handoff | Organized portfolio, final MVP scope, QA report, AI use summary, and technical defense prep. |
+
+## Strong Evidence Areas
+
+- Existing weekly sprint packets in [../../docs/Sprint-packets](../../docs/Sprint-packets).
+- Sprint summaries in [../../docs/Sprint](../../docs/Sprint).
+- Final screenshots in [../../demo-screenshots](../../demo-screenshots).
+- Current Java Servlet code in [../../Backend](../../Backend).
+- Frontend pages in [../../frontend](../../frontend).
+- Database schema in [../../database_schema.sql](../../database_schema.sql).
+- AI audit in [../../docs/AI_CODE_OWNERSHIP_AUDIT.md](../../docs/AI_CODE_OWNERSHIP_AUDIT.md).
+

--- a/portfolio/02-semester-journey/sprint-summaries/FINAL_SPRINT.md
+++ b/portfolio/02-semester-journey/sprint-summaries/FINAL_SPRINT.md
@@ -1,0 +1,51 @@
+# Final Sprint Summary
+
+## Goal
+
+Submit a complete final portfolio and prepare a reliable 15-minute final presentation.
+
+## Planned Work
+
+- Create `portfolio/` with all required sections.
+- Link all available evidence.
+- Add Week 1 through Week 16 files.
+- Add sprint summaries.
+- Add final product, QA, AI, presentation, and individual portfolio pages.
+- Make the root README point to the portfolio.
+
+## Completed Work
+
+- Required folder structure exists.
+- Portfolio README acts as the front door.
+- Final MVP scope, scope decisions, demo guide, setup guide, architecture, QA, bugs, AI use, and presentation docs exist.
+- Individual portfolio pages exist for all listed team members.
+- Existing evidence is linked instead of rewritten.
+
+## Incomplete Work
+
+- Team members should verify the spelling and content of individual pages.
+- The team should run one final demo rehearsal.
+- The team should add exact PR/issue links where available.
+
+## Scope Changes
+
+The final portfolio treats missing evidence honestly and links existing work. It does not create fake historical documents.
+
+## Strongest Evidence
+
+- [Portfolio README](../../README.md)
+- [Final MVP demo](../../04-final-product/FINAL_MVP_DEMO.md)
+- [QA report](../../05-qa-and-stabilization/QA_REPORT.md)
+- [AI use summary](../../06-ai-and-code-ownership/AI_USE_SUMMARY.md)
+- [Final presentation script](../../07-final-presentation/FINAL_PRESENTATION_SCRIPT.md)
+
+## Bugs Or Risks
+
+- Link drift if repository paths change after submission.
+- Demo risk if database or hosted environment is not configured.
+- Individual contribution evidence may need final student review.
+
+## Next Step
+
+Before the final deadline, open the deployed app and local backup, run the demo flow, check links, and rehearse technical defense answers.
+

--- a/portfolio/02-semester-journey/sprint-summaries/SPRINT_01.md
+++ b/portfolio/02-semester-journey/sprint-summaries/SPRINT_01.md
@@ -1,0 +1,44 @@
+# Sprint 01 Summary
+
+## Goal
+
+Define the StudentBridge project, target users, problem statement, and first buildable MVP direction.
+
+## Planned Work
+
+- Clarify the project idea.
+- Identify target users.
+- Create early project docs.
+- Draft user stories and team agreement.
+
+## Completed Work
+
+- Project overview and problem statement were created.
+- Team agreement and role expectations were documented.
+- Initial user stories and planning files were added.
+
+## Incomplete Work
+
+- No working product flow yet.
+- Evidence links were still mostly document-based.
+
+## Scope Changes
+
+The project narrowed from a broad employment-support idea into a student-friendly job search platform for international students and local employers.
+
+## Strongest Evidence
+
+- [Project overview](../../../docs/PROJECT_OVERVIEW.md)
+- [Project document](../../../docs/PROJECT.md)
+- [Team agreement](../../../docs/TEAM_AGREEMENT.md)
+- [User stories](../../../docs/USER_STORIES.md)
+
+## Bugs Or Risks
+
+- Risk of overscoping the platform.
+- Need to choose a simple, explainable stack.
+
+## Carryover
+
+Move from planning into a first visible frontend and architecture.
+

--- a/portfolio/02-semester-journey/sprint-summaries/SPRINT_02.md
+++ b/portfolio/02-semester-journey/sprint-summaries/SPRINT_02.md
@@ -1,0 +1,48 @@
+# Sprint 02 Summary
+
+## Goal
+
+Build a credible midterm demo path with homepage, job search, account screens, setup documentation, and a clear roadmap.
+
+## Planned Work
+
+- Create frontend pages.
+- Document architecture and setup.
+- Prepare demo flow and testing notes.
+- Keep final MVP scope realistic.
+
+## Completed Work
+
+- Homepage, job search, login, and register pages were represented in the repo.
+- Architecture and setup guide were documented.
+- Demo plan and testing notes were created.
+- Roadmap and known risks were recorded.
+
+## Incomplete Work
+
+- Register/login still depended on local Tomcat and MySQL setup.
+- Full application submission was not complete.
+- Evidence links still needed stronger screenshots, PRs, and issue links.
+
+## Scope Changes
+
+The team treated local Tomcat plus MySQL as the reliable demo path, while public deployment remained a later goal.
+
+## Strongest Evidence
+
+- [Sprint 2 notes](../../../docs/SPRINT_2.md)
+- [Architecture](../../../docs/ARCHITECTURE.md)
+- [Setup guide](../../../docs/SETUP_GUIDE.md)
+- [Testing notes](../../../docs/TESTING_NOTES.md)
+- [Demo plan](../../../docs/DEMO_PLAN.md)
+
+## Bugs Or Risks
+
+- Database credentials and setup could block demos.
+- Form action paths needed deployed testing.
+- Job data was not fully database-backed yet.
+
+## Carryover
+
+Stabilize backend, improve job data, and gather stronger evidence.
+

--- a/portfolio/02-semester-journey/sprint-summaries/SPRINT_03.md
+++ b/portfolio/02-semester-journey/sprint-summaries/SPRINT_03.md
@@ -1,0 +1,47 @@
+# Sprint 03 Summary
+
+## Goal
+
+Prove the MVP is real by improving backend integration, code ownership, QA notes, and evidence.
+
+## Planned Work
+
+- Improve servlet/database integration.
+- Document AI-assisted work and human ownership.
+- Add testing notes for core flows.
+- Continue UI and navigation cleanup.
+
+## Completed Work
+
+- Registration, login, logout, job, profile, and employer-related servlet files are present.
+- AI code ownership audit was created.
+- Testing notes captured compile, syntax, smoke-test, and deployment limitations.
+- Team roles and ownership areas were documented.
+
+## Incomplete Work
+
+- Some evidence still exists as local files rather than public PR/issue links.
+- Application submission was still incomplete at this stage of the semester.
+- Security hardening is not production-ready.
+
+## Scope Changes
+
+The project expanded beyond student-only job search to include employer posting and dashboard support, while keeping full application management as a future step.
+
+## Strongest Evidence
+
+- [AI code ownership audit](../../../docs/AI_CODE_OWNERSHIP_AUDIT.md)
+- [Testing notes](../../../docs/TESTING_NOTES.md)
+- [Team roles](../../../docs/TEAM_ROLES.md)
+- [Backend servlets](../../../Backend)
+- [Frontend pages](../../../frontend)
+
+## Bugs Or Risks
+
+- Plain-text passwords remain a security issue.
+- Environment-specific deployment can still fail without correct database variables.
+- Some code areas need stronger individual evidence links.
+
+## Carryover
+
+Finish final product documentation, deployment notes, QA report, and presentation readiness.

--- a/portfolio/02-semester-journey/sprint-summaries/SPRINT_04.md
+++ b/portfolio/02-semester-journey/sprint-summaries/SPRINT_04.md
@@ -1,0 +1,49 @@
+# Sprint 04 Summary
+
+## Goal
+
+Polish the final MVP, deployment path, screenshots, QA documentation, and portfolio structure.
+
+## Planned Work
+
+- Prepare final demo screenshots.
+- Document deployment and local fallback.
+- Organize final MVP scope.
+- Record bugs and limitations honestly.
+- Prepare portfolio and presentation materials.
+
+## Completed Work
+
+- Demo screenshots were added.
+- Render deployment files and guide exist.
+- Database schema supports users, profiles, and jobs.
+- Portfolio structure and final documents were created.
+- QA and limitation documents were created.
+
+## Incomplete Work
+
+- The team still needs to rehearse the final live demo.
+- Any remaining exact PR or issue links should be added if time allows.
+- Backup video is recommended but not found in the repository.
+
+## Scope Changes
+
+The final MVP prioritizes the demonstrable marketplace skeleton: search, accounts, student/employer role paths, employer job posting, MySQL schema, and deployment support.
+
+## Strongest Evidence
+
+- [Demo screenshots](../../../demo-screenshots)
+- [Render config](../../../render.yaml)
+- [Deployment guide](../../../docs/DEPLOY_RENDER.md)
+- [Database schema](../../../database_schema.sql)
+- [Final MVP demo](../../04-final-product/FINAL_MVP_DEMO.md)
+
+## Bugs Or Risks
+
+- Live demo can fail if hosted database environment variables are missing.
+- Local demo can fail if Tomcat or MySQL is not ready.
+- Security limitations must be acknowledged during defense.
+
+## Carryover
+
+Final rehearsal, link check, commit/push, and presentation defense.

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_01.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_01.md
@@ -1,0 +1,16 @@
+# Week 01
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 1](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week1.md)
+- [Project overview](../../../docs/PROJECT_OVERVIEW.md)
+- [Team agreement](../../../docs/TEAM_AGREEMENT.md)
+
+## Work Summary
+
+The team began organizing the StudentBridge idea, target users, and capstone workflow. The focus was defining a useful problem: helping international students in South Korea find student-friendly part-time jobs.
+
+## Evidence Notes
+
+The linked sprint packet and early project documents are the available evidence for this week. No extra historical files were invented.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_02.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_02.md
@@ -1,0 +1,16 @@
+# Week 02
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 2](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week2.md)
+- [Project document](../../../docs/PROJECT.md)
+- [User stories](../../../docs/USER_STORIES.md)
+
+## Work Summary
+
+The team refined the project goal, user groups, and early user stories. The MVP direction moved toward a job search platform with student and employer roles.
+
+## Evidence Notes
+
+This week is represented by the sprint packet and planning documents already in the repository.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_03.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_03.md
@@ -1,0 +1,16 @@
+# Week 03
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 3](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week3.md)
+- [User stories folder](../../../docs/UserStories)
+- [Questions and issues](../../../docs/Issues/Questions.md)
+
+## Work Summary
+
+The team continued translating the idea into buildable work: user stories, questions, and early feature priorities. This helped separate core MVP needs from stretch ideas.
+
+## Evidence Notes
+
+The available evidence is planning-heavy. That is expected for an early project week.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_04.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_04.md
@@ -1,0 +1,16 @@
+# Week 04
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 4](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week4.md)
+- [Architecture document](../../../docs/ARCHITECTURE.md)
+- [Design document](../../../docs/Design/design-doc-v1.md)
+
+## Work Summary
+
+The team shaped the technical architecture and UI direction. The selected stack became static frontend pages, Java Servlets, Tomcat, and MySQL.
+
+## Evidence Notes
+
+Architecture and design documents are the strongest available evidence for this week.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_05.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_05.md
@@ -1,0 +1,16 @@
+# Week 05
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 5](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week5.md)
+- [Roadmap](../../../docs/ROADMAP.md)
+- [Setup guide](../../../docs/SETUP_GUIDE.md)
+
+## Work Summary
+
+The team moved toward a first vertical slice: homepage, job discovery, setup instructions, and a path toward servlet/database integration.
+
+## Evidence Notes
+
+The repository contains enough planning and setup evidence to show the project was becoming buildable.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_06.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_06.md
@@ -1,0 +1,16 @@
+# Week 06
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 6](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week6.md)
+- [Sprint 2 notes](../../../docs/SPRINT_2.md)
+- [Testing notes](../../../docs/TESTING_NOTES.md)
+
+## Work Summary
+
+The team prepared the midterm-critical demo flow: homepage, jobs, registration, login, and known backend limitations. Testing notes started to capture the expected manual QA path.
+
+## Evidence Notes
+
+The sprint packet, Sprint 2 notes, and testing notes are the main evidence.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_07.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_07.md
@@ -1,0 +1,16 @@
+# Week 07
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 7](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week7.md)
+- [Demo plan](../../../docs/DEMO_PLAN.md)
+- [Midterm pitch notes](../../../docs/MIDTERM_PITCH_NOTES.md)
+
+## Work Summary
+
+The team prepared demo and pitch materials. The focus was explaining the problem clearly, showing the working parts, and documenting backup options for presentation risk.
+
+## Evidence Notes
+
+The demo plan and midterm pitch notes are the strongest evidence.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_08.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_08.md
@@ -1,0 +1,16 @@
+# Week 08
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 8](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week8.md)
+- [Brochure content](../../../docs/BROCHURE_CONTENT.md)
+- [Design package](../../../docs/DESIGN_PACKAGE.md)
+
+## Work Summary
+
+The team worked on presentation support and product communication. The project story became clearer for a non-technical audience while the implementation continued toward a reliable MVP.
+
+## Evidence Notes
+
+This week has product communication and design evidence in addition to sprint notes.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_09.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_09.md
@@ -1,0 +1,16 @@
+# Week 09
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 9](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week9.md)
+- [AI code ownership audit](../../../docs/AI_CODE_OWNERSHIP_AUDIT.md)
+- [Team roles](../../../docs/TEAM_ROLES.md)
+
+## Work Summary
+
+The team focused on proving the MVP was real and making ownership clearer. AI-assisted work, team roles, and explainability became important parts of the project evidence.
+
+## Evidence Notes
+
+This week is supported by the sprint packet, AI ownership audit, and team roles document.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_10.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_10.md
@@ -1,0 +1,16 @@
+# Week 10
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 10](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week10.md)
+- [Testing notes](../../../docs/TESTING_NOTES.md)
+- [Database jobs schema](../../../docs/database_jobs.sql)
+
+## Work Summary
+
+The team worked on bug triage, stabilization, and moving job data closer to a database-backed flow. Testing notes documented compile checks, frontend syntax checks, and static smoke testing.
+
+## Evidence Notes
+
+The testing notes include a Sprint Bugfix Validation section dated 2026-05-21.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_11.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_11.md
@@ -1,0 +1,16 @@
+# Week 11
+
+## Materials We Have
+
+- [Weekly Sprint Packet Week 11](../../../docs/Sprint-packets/Weekly%20Sprint%20Packet-Week11.md)
+- [Database schema](../../../database_schema.sql)
+- [Render deployment guide](../../../docs/DEPLOY_RENDER.md)
+
+## Work Summary
+
+The team pushed toward final MVP verification: deployment setup, database schema, and clearer evidence for the product flow.
+
+## Evidence Notes
+
+The current repository includes database, deployment, frontend, and backend evidence for this stage.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_12.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_12.md
@@ -1,0 +1,16 @@
+# Week 12
+
+## Materials We Have
+
+- [Sprint hardening commits in git history](../../../README.md)
+- [Render configuration](../../../render.yaml)
+- [Deployment script](../../../render-start.sh)
+
+## Work Summary
+
+The available repository history shows final hardening around deployment and database configuration. The team prepared the app to run beyond a local-only setup.
+
+## Note
+
+No formal Week 12 sprint packet was found in this repository. This file records the available evidence honestly.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_13.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_13.md
@@ -1,0 +1,16 @@
+# Week 13
+
+## Materials We Have
+
+- [Current frontend pages](../../../frontend)
+- [Current backend servlets](../../../Backend)
+- [Demo screenshots](../../../demo-screenshots)
+
+## Work Summary
+
+The project moved from earlier midterm documentation toward final product polish: employer pages, student profile, database-backed job data, and screenshot evidence.
+
+## Note
+
+No separate Week 13 packet was found. The evidence is the current implementation and screenshots.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_14.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_14.md
@@ -1,0 +1,16 @@
+# Week 14
+
+## Materials We Have
+
+- [QA report](../../05-qa-and-stabilization/QA_REPORT.md)
+- [Bugs and limitations](../../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md)
+- [Testing notes](../../../docs/TESTING_NOTES.md)
+
+## Work Summary
+
+The team focused on final QA, limitations, and presentation readiness. This portfolio records known weaknesses instead of hiding them.
+
+## Note
+
+No separate Week 14 packet was found. The final QA package is used as evidence.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_15.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_15.md
@@ -1,0 +1,16 @@
+# Week 15
+
+## Materials We Have
+
+- [Final MVP demo](../../04-final-product/FINAL_MVP_DEMO.md)
+- [Setup and run guide](../../04-final-product/SETUP_AND_RUN_GUIDE.md)
+- [Architecture final](../../04-final-product/ARCHITECTURE_FINAL.md)
+
+## Work Summary
+
+The team prepared final handoff documents so the instructor can understand the app, run it, and see the final MVP scope.
+
+## Note
+
+No separate Week 15 packet was found. The final handoff documents are the available evidence.
+

--- a/portfolio/02-semester-journey/weekly-sprints/WEEK_16.md
+++ b/portfolio/02-semester-journey/weekly-sprints/WEEK_16.md
@@ -1,0 +1,17 @@
+# Week 16
+
+## Materials We Have
+
+- [Portfolio front door](../../README.md)
+- [Final presentation script](../../07-final-presentation/FINAL_PRESENTATION_SCRIPT.md)
+- [Technical defense prep](../../07-final-presentation/TECHNICAL_DEFENSE_PREP.md)
+- [Backup demo plan](../../07-final-presentation/BACKUP_DEMO.md)
+
+## Work Summary
+
+The team completed the final portfolio structure, presentation package, and technical defense preparation before the June 17, 2026 final deadline.
+
+## Final Note
+
+This week is the final handoff week. The portfolio is designed to be the instructor-facing index for all major evidence.
+

--- a/portfolio/03-design-and-planning/README.md
+++ b/portfolio/03-design-and-planning/README.md
@@ -1,0 +1,19 @@
+# Design And Planning History
+
+This folder indexes the design and planning evidence already available in the repository. The portfolio links to the original files so the project history remains traceable.
+
+## Planning Index
+
+| Area | Portfolio folder | Evidence |
+|---|---|---|
+| Proposals and project idea | [proposals](proposals/README.md) | [../../docs/PROJECT.md](../../docs/PROJECT.md), [../../docs/PROJECT_OVERVIEW.md](../../docs/PROJECT_OVERVIEW.md), [../../docs/Issues/project_idea_pitch_issue.md](../../docs/Issues/project_idea_pitch_issue.md) |
+| User research and users | [user-research](user-research/README.md) | [../../docs/USER_STORIES.md](../../docs/USER_STORIES.md), [../../docs/UserStories](../../docs/UserStories) |
+| Wireframes and UI planning | [wireframes](wireframes/README.md) | [../../docs/DESIGN_PACKAGE.md](../../docs/DESIGN_PACKAGE.md), [../../docs/PAPER_DESIGN_UI_SPEC.md](../../docs/PAPER_DESIGN_UI_SPEC.md), [../../docs/umm/ui flowchart.png](../../docs/umm/ui%20flowchart.png) |
+| Architecture | [architecture](architecture/README.md) | [../../docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md), [../../docs/Architecture/ARCHITECTURE.md](../../docs/Architecture/ARCHITECTURE.md) |
+| Risk and scope | [risk-and-scope](risk-and-scope/README.md) | [../01-project-overview/FINAL_MVP_SCOPE.md](../01-project-overview/FINAL_MVP_SCOPE.md), [../01-project-overview/SCOPE_DECISIONS.md](../01-project-overview/SCOPE_DECISIONS.md), [../../docs/ROADMAP.md](../../docs/ROADMAP.md) |
+| Planning docs | [planning-docs](planning-docs/README.md) | [../../docs/TEAM_AGREEMENT.md](../../docs/TEAM_AGREEMENT.md), [../../docs/TEAM_ROLES.md](../../docs/TEAM_ROLES.md), [../../docs/Sprint-packets](../../docs/Sprint-packets) |
+
+## Historical Integrity Note
+
+The repository does not contain every possible version of every planning file. Where older versions are not available, this portfolio says so and links the real evidence that exists.
+

--- a/portfolio/03-design-and-planning/architecture/README.md
+++ b/portfolio/03-design-and-planning/architecture/README.md
@@ -1,0 +1,23 @@
+# Architecture Planning
+
+## Available Evidence
+
+- [Main architecture document](../../../docs/ARCHITECTURE.md)
+- [Architecture folder copy](../../../docs/Architecture/ARCHITECTURE.md)
+- [Final architecture](../../04-final-product/ARCHITECTURE_FINAL.md)
+- [Database schema](../../../database_schema.sql)
+- [Deployment guide](../../../docs/DEPLOY_RENDER.md)
+
+## Architecture Summary
+
+StudentBridge uses a simple capstone-friendly architecture:
+
+- HTML, CSS, and JavaScript frontend.
+- Java Servlets on Apache Tomcat.
+- MySQL database accessed with JDBC.
+- Render deployment support with environment variables.
+
+## Decision
+
+The team kept the stack intentionally understandable so members can explain, test, and debug the work during technical defense.
+

--- a/portfolio/03-design-and-planning/planning-docs/README.md
+++ b/portfolio/03-design-and-planning/planning-docs/README.md
@@ -1,0 +1,19 @@
+# Planning Documents
+
+## Available Evidence
+
+- [Docs index](../../../docs/README.md)
+- [Team agreement](../../../docs/TEAM_AGREEMENT.md)
+- [Team roles](../../../docs/TEAM_ROLES.md)
+- [Roadmap](../../../docs/ROADMAP.md)
+- [Sprint packets](../../../docs/Sprint-packets)
+- [Sprint summaries](../../../docs/Sprint)
+
+## Summary
+
+The planning history shows the team defining roles, building sprint packets, preparing demos, tracking risks, and gradually turning the MVP into a final handoff package.
+
+## Note
+
+The final portfolio keeps these files in place and links to them because moving older documents could break evidence paths.
+

--- a/portfolio/03-design-and-planning/proposals/README.md
+++ b/portfolio/03-design-and-planning/proposals/README.md
@@ -1,0 +1,17 @@
+# Proposals
+
+## Available Evidence
+
+- [Project overview](../../../docs/PROJECT_OVERVIEW.md)
+- [Project document](../../../docs/PROJECT.md)
+- [Project idea pitch issue](../../../docs/Issues/project_idea_pitch_issue.md)
+- [Midterm pitch notes](../../../docs/MIDTERM_PITCH_NOTES.md)
+
+## Summary
+
+StudentBridge was proposed as a capstone platform for international students in South Korea who need part-time jobs and for local employers who want student workers. The proposal evolved toward a practical MVP: job search, account flow, employer job posting, and MySQL-backed data.
+
+## Missing Evidence Note
+
+No separate `proposal-v1`, `proposal-v2`, and `proposal-final` files were found. The linked project and pitch documents are the proposal evidence available in this repository.
+

--- a/portfolio/03-design-and-planning/risk-and-scope/README.md
+++ b/portfolio/03-design-and-planning/risk-and-scope/README.md
@@ -1,0 +1,21 @@
+# Risk And Scope
+
+## Available Evidence
+
+- [Final MVP scope](../../01-project-overview/FINAL_MVP_SCOPE.md)
+- [Scope decisions](../../01-project-overview/SCOPE_DECISIONS.md)
+- [Roadmap](../../../docs/ROADMAP.md)
+- [Testing notes](../../../docs/TESTING_NOTES.md)
+- [Bugs and limitations](../../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md)
+- [AI code ownership audit](../../../docs/AI_CODE_OWNERSHIP_AUDIT.md)
+
+## Main Risks
+
+| Risk | Status |
+|---|---|
+| Demo depends on Tomcat/MySQL or hosted database setup | Documented with local and Render options. |
+| Plain-text password storage | Accepted limitation for demo, not acceptable for real users. |
+| Full application submission incomplete | Documented as next step. |
+| Missing PR/issue evidence for some work | Mitigated by linking files, screenshots, and docs. |
+| AI-assisted code ownership | Documented through AI audit and individual portfolios. |
+

--- a/portfolio/03-design-and-planning/user-research/README.md
+++ b/portfolio/03-design-and-planning/user-research/README.md
@@ -1,0 +1,22 @@
+# User Research
+
+## Available Evidence
+
+- [User stories](../../../docs/USER_STORIES.md)
+- [User stories folder](../../../docs/UserStories)
+- [Questions document](../../../docs/Issues/Questions.md)
+
+## Target Users
+
+- International students in South Korea.
+- Local employers who hire student workers.
+- University support staff who help students find employment resources.
+
+## Research Summary
+
+The repository mainly contains user-story and problem-definition evidence rather than formal interview transcripts. The strongest insight is that students need clearer job filtering, safer job information, and a simpler route from discovery to application.
+
+## Missing Evidence Note
+
+No formal interview notes were found. This portfolio does not invent interviews.
+

--- a/portfolio/03-design-and-planning/wireframes/README.md
+++ b/portfolio/03-design-and-planning/wireframes/README.md
@@ -1,0 +1,18 @@
+# Wireframes And UI Planning
+
+## Available Evidence
+
+- [Design package](../../../docs/DESIGN_PACKAGE.md)
+- [Paper design UI spec](../../../docs/PAPER_DESIGN_UI_SPEC.md)
+- [UI flowchart image](../../../docs/umm/ui%20flowchart.png)
+- [Frontend pages](../../../frontend)
+- [Demo screenshots](../../../demo-screenshots)
+
+## Summary
+
+UI planning focused on a straightforward product path: homepage, job search, login/register, employer dashboard, post-job form, and student profile. The current screenshots show the final visual direction more clearly than early wireframe text.
+
+## Missing Evidence Note
+
+If paper sketches or external design files exist outside the repo, they should be linked here later. This folder currently links the UI evidence available in GitHub.
+

--- a/portfolio/04-final-product/ARCHITECTURE_FINAL.md
+++ b/portfolio/04-final-product/ARCHITECTURE_FINAL.md
@@ -1,0 +1,76 @@
+# Final Architecture
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Frontend | HTML, CSS, JavaScript |
+| Backend | Java Servlets |
+| Server | Apache Tomcat |
+| Database | MySQL |
+| Database access | JDBC / MySQL Connector |
+| Hosting | Render with local Tomcat fallback |
+
+## System Diagram
+
+```mermaid
+flowchart LR
+    Student["Student browser"] --> Frontend["HTML/CSS/JS pages"]
+    Employer["Employer browser"] --> Frontend
+    Frontend --> Tomcat["Tomcat / Render web service"]
+    Tomcat --> Servlets["Java Servlets"]
+    Servlets --> JDBC["JDBC"]
+    JDBC --> MySQL["MySQL database"]
+```
+
+## Major Folders
+
+| Folder | Purpose |
+|---|---|
+| `frontend/` | Login, register, job search, student profile, employer dashboard, post-job page, shared scripts and styles. |
+| `Backend/` | Java Servlet source files and database connection helper. |
+| `server/` | Local jar dependencies for MySQL and Servlet API. |
+| `docs/` | Project docs, setup, architecture, testing, deployment, AI audit, sprint packets. |
+| `demo-screenshots/` | Final product screenshots used for backup demo and portfolio. |
+| `portfolio/` | Final handoff package for instructor review. |
+
+## Major Components And Endpoints
+
+| Component | Files | Purpose |
+|---|---|---|
+| Homepage | `index.html`, `frontend/style.css`, `frontend/script.js` | Product story and navigation. |
+| Job search | `frontend/jobsearch.html`, `Backend/JobServlet.java` | Displays and loads job listings. |
+| Register | `frontend/register.html`, `Backend/RegisterServlet.java` | Creates user accounts. |
+| Login/logout | `frontend/login.html`, `Backend/LoginServlet.java`, `Backend/LogoutServlet.java` | Authenticates users and manages session state. |
+| Student profile | `frontend/student-profile.html`, `Backend/StudentProfileServlet.java` | Shows student profile data. |
+| Employer dashboard | `frontend/employer-dashboard.html`, `Backend/EmployerApplicationsServlet.java` | Shows employer-side application activity. |
+| Post job | `frontend/post-job.html`, `Backend/PostJobServlet.java` | Lets employers create job posts. |
+| Apply to job | `Backend/ApplyServlet.java` | Lets logged-in students apply to jobs when profile/CV data is available. |
+| Messages and notifications | `Backend/MessageServlet.java`, `Backend/NotificationServlet.java` | Supports follow-up and user notifications. |
+| Database | `database_schema.sql`, `docs/database_jobs.sql` | Defines users, profiles, and jobs. |
+
+## Data Model
+
+| Table | Purpose |
+|---|---|
+| `users` | Stores basic user account data and account type. |
+| `student_profiles` | Stores student education, preferences, address, and coordinates. |
+| `employer_profiles` | Stores employer business information. |
+| `jobs` | Stores job posts, company data, contact details, deadline, address, and coordinates. |
+| `applications` | Stores student applications to jobs. |
+| `notifications` | Stores in-app notification records. |
+| `conversations` and `messages` | Stores employer/student follow-up messages. |
+
+## External Services
+
+| Service | Purpose |
+|---|---|
+| Render | Hosted demo target. |
+| Hosted MySQL-compatible database | Production-like database for Render. |
+
+## Architecture Risks
+
+- Session-based role flows need careful testing in the deployed environment.
+- Password storage is not production secure.
+- Application submission depends on profile/CV data and seeded demo users.
+- Hosted database variables must be configured correctly.

--- a/portfolio/04-final-product/DEPLOYMENT_AND_DEMO_PLAN.md
+++ b/portfolio/04-final-product/DEPLOYMENT_AND_DEMO_PLAN.md
@@ -1,0 +1,47 @@
+# Deployment And Demo Plan
+
+## Demo Environments
+
+| Environment | Purpose | Link |
+|---|---|---|
+| Render | Primary public demo if healthy. | <https://studentbridge-6jn2.onrender.com> |
+| Local Tomcat | Backup and developer demo. | <http://localhost:8080/StudentBridge/> |
+| Screenshots | Backup if live app or internet fails. | [../../demo-screenshots](../../demo-screenshots) |
+
+## Required Accounts And Devices
+
+- One laptop with Chrome.
+- GitHub access to the repository.
+- Render dashboard access if deployment needs checking.
+- MySQL access for local or hosted database.
+- Demo student and employer accounts.
+
+## Demo Data
+
+| Data | Source |
+|---|---|
+| Demo users | Register through app or seed manually. |
+| Demo jobs | [../../docs/database_jobs.sql](../../docs/database_jobs.sql) |
+| Schema | [../../database_schema.sql](../../database_schema.sql) |
+
+## Known Demo Risks
+
+| Risk | Backup |
+|---|---|
+| Render app unavailable | Use local Tomcat. |
+| Local database unavailable | Use screenshots and explain database setup. |
+| Login/register fails | Show code, setup guide, and screenshots. |
+| Job posting fails | Show schema, servlet code, and post-job screenshot. |
+| Internet fails | Use local screenshots and repository files. |
+
+## Final Rehearsal Checklist
+
+- [ ] Open Render app.
+- [ ] Open local Tomcat app.
+- [ ] Confirm jobs page loads.
+- [ ] Confirm login/register pages load.
+- [ ] Confirm employer dashboard and post-job pages load.
+- [ ] Confirm screenshots open locally.
+- [ ] Confirm presentation script fits 15 minutes.
+- [ ] Confirm each member can answer their technical ownership question.
+

--- a/portfolio/04-final-product/FINAL_MVP_DEMO.md
+++ b/portfolio/04-final-product/FINAL_MVP_DEMO.md
@@ -1,0 +1,59 @@
+# Final MVP Demo
+
+## Demo Goal
+
+Show that StudentBridge is a real capstone MVP for international student job discovery, with a working frontend, Java Servlet backend, MySQL schema, employer job-posting path, deployment support, and honest limitations.
+
+## Primary Demo Access
+
+| Option | Link |
+|---|---|
+| Deployed app | <https://studentbridge-6jn2.onrender.com> |
+| Local Tomcat | <http://localhost:8080/StudentBridge/> |
+| Repository | <https://github.com/CapstoneDesign-Spring2026-UlsanCollege/StudentBridge> |
+
+## Demo Credentials
+
+Use demo-only data. Do not use real student personal information.
+
+| Account | Value |
+|---|---|
+| Student email | `demo.student@example.com` |
+| Employer email | `demo.employer@example.com` |
+| Password | `demo1234` |
+
+If these accounts are not already in the database, create them through the registration page before the presentation.
+
+## Main User Flow
+
+1. Open StudentBridge.
+2. Explain the target user: international students in South Korea.
+3. Open Jobs and show search/filter behavior.
+4. Register or log in as a student.
+5. Show the student profile page.
+6. Log in as an employer or explain the employer role.
+7. Open employer dashboard and post-job flow.
+8. Show that job and application data are backed by the MySQL schema when the database is configured.
+9. Explain the apply flow: a logged-in student applies to a job when a profile CV link exists.
+10. Finish with known limitations: production security and final accessibility review are next steps.
+
+## Screenshots
+
+| Screenshot | Link |
+|---|---|
+| Homepage | [../../demo-screenshots/01-home.png](../../demo-screenshots/01-home.png) |
+| Login | [../../demo-screenshots/02-login.png](../../demo-screenshots/02-login.png) |
+| Register student | [../../demo-screenshots/03-register-student.png](../../demo-screenshots/03-register-student.png) |
+| Job search | [../../demo-screenshots/04-jobsearch.png](../../demo-screenshots/04-jobsearch.png) |
+| Employer dashboard | [../../demo-screenshots/05-employer-dashboard.png](../../demo-screenshots/05-employer-dashboard.png) |
+| Post job | [../../demo-screenshots/06-post-job.png](../../demo-screenshots/06-post-job.png) |
+| Student profile | [../../demo-screenshots/07-student-profile.png](../../demo-screenshots/07-student-profile.png) |
+
+## Evidence Links
+
+- [Frontend pages](../../frontend)
+- [Backend servlets](../../Backend)
+- [Database schema](../../database_schema.sql)
+- [Render deployment guide](../../docs/DEPLOY_RENDER.md)
+- [Testing notes](../../docs/TESTING_NOTES.md)
+- [Bugs and limitations](../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md)

--- a/portfolio/04-final-product/SETUP_AND_RUN_GUIDE.md
+++ b/portfolio/04-final-product/SETUP_AND_RUN_GUIDE.md
@@ -1,0 +1,114 @@
+# Setup And Run Guide
+
+## Required Software
+
+| Tool | Recommended |
+|---|---|
+| Java | JDK 17 or newer |
+| Server | Apache Tomcat 10.1.x |
+| Database | MySQL 8.x or hosted MySQL-compatible database |
+| Browser | Chrome, Edge, or Firefox |
+| Shell | macOS/Linux terminal |
+
+## Clone
+
+```bash
+git clone https://github.com/CapstoneDesign-Spring2026-UlsanCollege/StudentBridge.git
+cd StudentBridge
+```
+
+## Database Setup
+
+Run the schema in MySQL:
+
+```bash
+mysql -u root -p < database_schema.sql
+```
+
+For extra demo job rows, use:
+
+```bash
+mysql -u root -p studentbridge < docs/database_jobs.sql
+```
+
+## Environment Variables
+
+The current `DBConnection` supports these variables:
+
+| Variable | Purpose |
+|---|---|
+| `DB_URL` | Full JDBC URL. Optional if host, port, and name are set. |
+| `DB_HOST` | MySQL host. |
+| `DB_PORT` | MySQL port, usually `3306`. |
+| `DB_NAME` | Database name, usually `studentbridge`. |
+| `DB_USER` | Database username. |
+| `DB_PASSWORD` | Database password. |
+
+Use `.env.example` and deployment docs as references. Do not commit real passwords.
+
+## Local Tomcat Run
+
+The existing setup guide has the detailed Tomcat path notes:
+
+- [../../docs/SETUP_GUIDE.md](../../docs/SETUP_GUIDE.md)
+
+Typical run:
+
+```bash
+chmod +x deploy.sh
+./deploy.sh
+```
+
+Then start Tomcat and open:
+
+```text
+http://localhost:8080/StudentBridge/
+```
+
+## Manual Compile Check
+
+```bash
+javac -cp "server/mysql-connector-j-9.3.0.jar:server/servlet-api.jar" -d bin Backend/*.java
+```
+
+## Test Commands
+
+Frontend syntax checks:
+
+```bash
+node --check frontend/script.js
+node --check frontend/platform.js
+node --check frontend/runtime-config.js
+```
+
+Backend compile check:
+
+```bash
+javac -cp "server/mysql-connector-j-9.3.0.jar:server/servlet-api.jar" -d bin Backend/*.java
+```
+
+## Seed Data
+
+Use demo-only users and jobs. Avoid real passwords and personal information in screenshots.
+
+```sql
+INSERT INTO users (name, email, phone, password, account_type)
+VALUES ('Demo Student', 'demo.student@example.com', '010-0000-0000', 'demo1234', 'Student');
+```
+
+## Troubleshooting
+
+| Problem | Likely cause | Fix |
+|---|---|---|
+| Homepage 404 | Tomcat app path is wrong. | Confirm files copied to `webapps/StudentBridge`. |
+| Servlet 404 | Classes missing or Tomcat not restarted. | Run `./deploy.sh` and restart Tomcat. |
+| Database error | MySQL stopped, schema missing, or env vars wrong. | Start MySQL and verify `DB_*` variables. |
+| Jobs page empty | `jobs` table missing or not seeded. | Run `database_schema.sql` and `docs/database_jobs.sql`. |
+| Render fails | Missing hosted DB vars or port/start issue. | Follow [deployment guide](../../docs/DEPLOY_RENDER.md). |
+
+## Known Setup Limitations
+
+- Local Tomcat path may need editing in `deploy.sh`.
+- Passwords are demo-only and not production-secure.
+- Hosted deployment depends on external database configuration.
+

--- a/portfolio/04-final-product/screenshots/README.md
+++ b/portfolio/04-final-product/screenshots/README.md
@@ -1,0 +1,14 @@
+# Screenshot Index
+
+The screenshot files are stored in the root-level [demo-screenshots](../../../demo-screenshots) folder.
+
+| File | Meaning |
+|---|---|
+| [01-home.png](../../../demo-screenshots/01-home.png) | Homepage. |
+| [02-login.png](../../../demo-screenshots/02-login.png) | Login page. |
+| [03-register-student.png](../../../demo-screenshots/03-register-student.png) | Student registration page. |
+| [04-jobsearch.png](../../../demo-screenshots/04-jobsearch.png) | Job search page. |
+| [05-employer-dashboard.png](../../../demo-screenshots/05-employer-dashboard.png) | Employer dashboard. |
+| [06-post-job.png](../../../demo-screenshots/06-post-job.png) | Post job page. |
+| [07-student-profile.png](../../../demo-screenshots/07-student-profile.png) | Student profile page. |
+

--- a/portfolio/05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md
+++ b/portfolio/05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md
@@ -1,0 +1,19 @@
+# Bugs And Limitations
+
+| Bug or limitation | Severity | Status | Evidence | Workaround or next step |
+|---|---|---|---|---|
+| Application submission depends on logged-in student session and CV link in profile. | P1 | Mitigated | [Apply servlet](../../Backend/ApplyServlet.java) | Seed demo student profile/CV data and test before presentation. |
+| Passwords are not production-secure. | P1 | Accepted for demo | [AI audit](../../docs/AI_CODE_OWNERSHIP_AUDIT.md) | Add hashing before real users. |
+| Database/demo depends on environment variables and MySQL availability. | P1 | Mitigated | [Setup guide](../04-final-product/SETUP_AND_RUN_GUIDE.md) | Test hosted and local DB before presentation. |
+| Render app can fail if hosted database is not configured. | P1 | Mitigated | [Deployment plan](../04-final-product/DEPLOYMENT_AND_DEMO_PLAN.md) | Use local Tomcat or screenshots as backup. |
+| Some historical weeks do not have formal sprint packets. | P2 | Documented | [Semester journey](../02-semester-journey/SEMESTER_JOURNEY.md) | Use honest notes and link available evidence. |
+| Some contribution evidence lacks exact PR/issue links. | P2 | Documented | [Individual portfolios](../08-individual-portfolios/MEZBAH_UDDIN.md) | Team members should add exact PR/commit links if time allows. |
+| Full accessibility audit is not complete. | P3 | Open | [QA report](QA_REPORT.md) | Run keyboard, label, contrast, and responsive checks. |
+| Backup video was not found in repo. | P3 | Open | [Backup demo](../07-final-presentation/BACKUP_DEMO.md) | Record a 2-3 minute screen capture if possible. |
+
+## Severity Guide
+
+- P0: final demo cannot work.
+- P1: core feature broken or unreliable.
+- P2: important but workaround exists.
+- P3: polish or nice improvement.

--- a/portfolio/05-qa-and-stabilization/QA_REPORT.md
+++ b/portfolio/05-qa-and-stabilization/QA_REPORT.md
@@ -1,0 +1,72 @@
+# QA Report
+
+## QA Goal
+
+Prove that the final MVP can be demonstrated clearly, and document the exact limits that remain before StudentBridge could be used by real students and employers.
+
+## Test Environment
+
+| Item | Value |
+|---|---|
+| Browser | Chrome recommended |
+| Backend | Java Servlets |
+| Server | Apache Tomcat locally, Render for hosted demo |
+| Database | MySQL |
+| Local URL | <http://localhost:8080/StudentBridge/> |
+| Hosted URL | <https://studentbridge-6jn2.onrender.com> |
+
+## Core Flow Checklist
+
+| ID | Flow | Expected result | Status | Evidence |
+|---|---|---|---|---|
+| QA-01 | Open homepage | Homepage loads with navigation and calls to action. | Ready for demo | [Screenshot](../../demo-screenshots/01-home.png) |
+| QA-02 | Open login | Login page loads. | Ready for demo | [Screenshot](../../demo-screenshots/02-login.png) |
+| QA-03 | Open register | Student registration page loads. | Ready for demo | [Screenshot](../../demo-screenshots/03-register-student.png) |
+| QA-04 | Open jobs | Job search page loads. | Ready for demo | [Screenshot](../../demo-screenshots/04-jobsearch.png) |
+| QA-05 | Open employer dashboard | Employer dashboard page is available. | Ready for demo with login/session setup | [Screenshot](../../demo-screenshots/05-employer-dashboard.png) |
+| QA-06 | Open post job | Post-job form is available. | Ready for demo with employer login/session setup | [Screenshot](../../demo-screenshots/06-post-job.png) |
+| QA-07 | Open student profile | Student profile page is available. | Ready for demo with student login/session setup | [Screenshot](../../demo-screenshots/07-student-profile.png) |
+| QA-08 | Compile backend | Servlet files should compile with provided jars. | Needs final rerun before presentation | [Setup guide](../04-final-product/SETUP_AND_RUN_GUIDE.md) |
+| QA-09 | Render deployment | Hosted app should open if environment variables are configured. | Needs final live check | [Deployment guide](../../docs/DEPLOY_RENDER.md) |
+| QA-10 | Application submission | Student applies to job and app stores result. | Needs final live rerun | [Apply servlet](../../Backend/ApplyServlet.java) |
+
+## Existing Validation Evidence
+
+The repository includes a Sprint Bugfix Validation section in [../../docs/TESTING_NOTES.md](../../docs/TESTING_NOTES.md) dated 2026-05-21. It records:
+
+- Servlet compile check passed.
+- Shared frontend scripts syntax check passed.
+- Static browser smoke tests passed without console errors.
+- Docker build was not run because Docker was unavailable locally.
+
+## Manual Tests To Run Before Presentation
+
+| Test | Command or action |
+|---|---|
+| Backend compile | `javac -cp "server/mysql-connector-j-9.3.0.jar:server/servlet-api.jar" -d bin Backend/*.java` |
+| Frontend scripts | `node --check frontend/script.js` |
+| Homepage | Open hosted app and local Tomcat app. |
+| Jobs | Search and filter jobs. |
+| Register/login | Create a demo user and log in. |
+| Employer post job | Log in as employer and submit one demo job. |
+| MySQL verification | `SELECT id, title, company FROM jobs ORDER BY id DESC LIMIT 5;` |
+
+## Browser Or Device Checks
+
+- Desktop Chrome is the main presentation target.
+- The frontend should remain usable on narrower screens because the shared nav and layout styles were polished during the final sprint.
+- Mobile testing should be treated as a demo confidence check, not a full production certification.
+
+## Accessibility And Security Basics
+
+| Area | Status |
+|---|---|
+| Keyboard navigation | Basic browser behavior available, but full accessibility audit not complete. |
+| Form labels | Main forms use visible labels/fields; needs final manual check. |
+| Password security | Password hashing remains a known limitation before real users. |
+| Secrets | `.env.example` exists; real credentials should stay out of screenshots and commits. |
+| SQL safety | Servlet code uses prepared statements in key database flows. |
+
+## Deployment Reliability
+
+Render deployment exists, but local Tomcat should remain the backup. The demo team should test both paths on presentation morning.

--- a/portfolio/05-qa-and-stabilization/qa-checklists/README.md
+++ b/portfolio/05-qa-and-stabilization/qa-checklists/README.md
@@ -1,0 +1,9 @@
+# QA Checklists
+
+Use [../QA_REPORT.md](../QA_REPORT.md) as the main final QA checklist.
+
+Additional source evidence:
+
+- [../../../docs/TESTING_NOTES.md](../../../docs/TESTING_NOTES.md)
+- [../../../docs/DEMO_PLAN.md](../../../docs/DEMO_PLAN.md)
+

--- a/portfolio/05-qa-and-stabilization/refactor-evidence/README.md
+++ b/portfolio/05-qa-and-stabilization/refactor-evidence/README.md
@@ -1,0 +1,13 @@
+# Refactor Evidence
+
+## Available Evidence
+
+- Git history includes final hardening commits.
+- Shared frontend files: [../../../frontend/style.css](../../../frontend/style.css), [../../../frontend/script.js](../../../frontend/script.js)
+- Database deployment hardening: [../../../Backend/DBConnection.java](../../../Backend/DBConnection.java)
+- Deployment docs: [../../../docs/DEPLOY_RENDER.md](../../../docs/DEPLOY_RENDER.md)
+
+## Summary
+
+The final sprint focused on stabilizing the app for demo, improving navigation and deployment readiness, and organizing the final handoff package.
+

--- a/portfolio/05-qa-and-stabilization/test-evidence/README.md
+++ b/portfolio/05-qa-and-stabilization/test-evidence/README.md
@@ -1,0 +1,16 @@
+# Test Evidence
+
+## Available Evidence
+
+- [Testing notes](../../../docs/TESTING_NOTES.md)
+- [Demo screenshots](../../../demo-screenshots)
+- [Backend servlets](../../../Backend)
+- [Database schema](../../../database_schema.sql)
+
+## Evidence Still Recommended
+
+- Terminal screenshot of final backend compile.
+- Screenshot of hosted app loading on Render.
+- Screenshot of MySQL jobs table after demo seed data.
+- Short backup video of the final demo flow.
+

--- a/portfolio/06-ai-and-code-ownership/AI_CODE_OWNERSHIP_AUDIT.md
+++ b/portfolio/06-ai-and-code-ownership/AI_CODE_OWNERSHIP_AUDIT.md
@@ -1,0 +1,21 @@
+# AI Code Ownership Audit
+
+The original project audit is available at [../../docs/AI_CODE_OWNERSHIP_AUDIT.md](../../docs/AI_CODE_OWNERSHIP_AUDIT.md).
+
+## Final Portfolio Update
+
+For final submission, the ownership map is also reflected in:
+
+- [AI use summary](AI_USE_SUMMARY.md)
+- [Mezbah Uddin individual portfolio](../08-individual-portfolios/MEZBAH_UDDIN.md)
+- [Sami Ul Alim individual portfolio](../08-individual-portfolios/SAMI_UL_ALIM.md)
+- [Ali Mohamad Ashraf individual portfolio](../08-individual-portfolios/ALI_MOHAMAD_ASHRAF.md)
+- [Guramg Roman individual portfolio](../08-individual-portfolios/GURAMG_ROMAN.md)
+- [Dipesh Chaulagain individual portfolio](../08-individual-portfolios/DIPESH_CHAULAGAIN.md)
+
+## Final Ownership Risks
+
+- Some evidence links should be replaced with exact PR or commit links if the team has time.
+- Every student should rehearse one code, doc, or QA area they can explain clearly.
+- No student should claim AI-assisted code as finished without being able to run and explain it.
+

--- a/portfolio/06-ai-and-code-ownership/AI_USE_SUMMARY.md
+++ b/portfolio/06-ai-and-code-ownership/AI_USE_SUMMARY.md
@@ -1,0 +1,62 @@
+# AI Use Summary
+
+## Rule
+
+AI-assisted work only counts if the team can run it, explain it, test it, debug it, and link evidence.
+
+## AI Tools Used
+
+| Tool | Use |
+|---|---|
+| ChatGPT / Codex-style assistant | Helped draft code, organize documentation, debug setup, improve UI, and prepare final portfolio structure. |
+| GitHub Copilot or similar AI assistance | May have supported code drafting and refactoring; team should verify exact usage. |
+
+## What AI Helped With
+
+- UI copy and layout ideas.
+- Java Servlet and JDBC examples.
+- Documentation organization.
+- Setup and deployment notes.
+- QA checklist drafting.
+- Final portfolio structure.
+
+## What Humans Reviewed Or Changed
+
+- Team members kept the project stack as Java Servlet, Tomcat, MySQL, HTML, CSS, and JavaScript.
+- Team members tested or prepared to test flows locally and through deployment.
+- Team members adjusted UI pages, backend servlets, database schema, and demo documentation.
+- Team members remain responsible for explaining their owned areas during technical defense.
+
+## How AI-Assisted Work Was Tested
+
+- Backend compile checks documented in [../../docs/TESTING_NOTES.md](../../docs/TESTING_NOTES.md).
+- Frontend syntax checks documented in [../../docs/TESTING_NOTES.md](../../docs/TESTING_NOTES.md).
+- Manual demo screenshots stored in [../../demo-screenshots](../../demo-screenshots).
+- Final QA checklist in [../05-qa-and-stabilization/QA_REPORT.md](../05-qa-and-stabilization/QA_REPORT.md).
+
+## Code Areas Students Can Explain
+
+| Student | Area |
+|---|---|
+| Mezbah Uddin | Backend setup, database connection, homepage, deployment configuration. |
+| Sami Ul Alim | Job search UI and frontend behavior. |
+| Ali Mohamad Ashraf | Login flow, job page support, servlet/frontend integration. |
+| Guramg Roman | Documentation, sprint evidence, project history. |
+| Dipesh Chaulagain | QA checklist, test evidence, demo validation. |
+
+## Confusing Or Risky Code Areas
+
+| Area | Risk | Next step |
+|---|---|---|
+| Session and account-type routing | Demo can fail if session state is not created correctly. | Rehearse student and employer login. |
+| Database environment variables | Hosted app fails if variables are missing. | Verify Render config before demo. |
+| Password handling | Not safe for real users. | Add hashing after class demo. |
+| Application submission | Depends on student profile/CV data and session state. | Seed demo data and rehearse before presentation. |
+
+## Representative Evidence
+
+- [AI code ownership audit](../../docs/AI_CODE_OWNERSHIP_AUDIT.md)
+- [Backend source](../../Backend)
+- [Frontend source](../../frontend)
+- [Testing notes](../../docs/TESTING_NOTES.md)
+- [Individual portfolios](../08-individual-portfolios/MEZBAH_UDDIN.md)

--- a/portfolio/06-ai-and-code-ownership/representative-prs/README.md
+++ b/portfolio/06-ai-and-code-ownership/representative-prs/README.md
@@ -1,0 +1,27 @@
+# Representative PRs And Commits
+
+## Available Evidence
+
+The portfolio currently uses file-level and screenshot evidence because exact PR links were not all identified in the local checkout.
+
+Useful GitHub evidence to add if time allows:
+
+- PR for profile icon / navigation updates.
+- PR for servlet updates.
+- PR for database deployment hardening.
+- PR for Render deployment docs.
+- PR for final portfolio.
+
+## Local Git History Pointers
+
+Recent local commits include:
+
+- `Harden database deployment config`
+- `Fix sprint handoff bugs`
+- `Add real page link to demo section`
+- `Replace email with profile icon`
+- `Update JobServlet.java`
+- `Update LoginServlet.java`
+- `Update PostJobServlet.java`
+- `Update RegisterServlet.java`
+

--- a/portfolio/07-final-presentation/BACKUP_DEMO.md
+++ b/portfolio/07-final-presentation/BACKUP_DEMO.md
@@ -1,0 +1,40 @@
+# Backup Demo
+
+## Backup Goal
+
+Keep the final presentation moving if Render, internet, Tomcat, or MySQL fails.
+
+## Backup Order
+
+1. Try Render: <https://studentbridge-6jn2.onrender.com>
+2. Try local Tomcat: <http://localhost:8080/StudentBridge/>
+3. Use screenshots from [../../demo-screenshots](../../demo-screenshots).
+4. Show code and database schema in the repository.
+5. Explain the limitation using [../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md](../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md).
+
+## Screenshot Backup Flow
+
+| Step | Screenshot |
+|---|---|
+| Homepage | [01-home.png](../../demo-screenshots/01-home.png) |
+| Login | [02-login.png](../../demo-screenshots/02-login.png) |
+| Register | [03-register-student.png](../../demo-screenshots/03-register-student.png) |
+| Job search | [04-jobsearch.png](../../demo-screenshots/04-jobsearch.png) |
+| Employer dashboard | [05-employer-dashboard.png](../../demo-screenshots/05-employer-dashboard.png) |
+| Post job | [06-post-job.png](../../demo-screenshots/06-post-job.png) |
+| Student profile | [07-student-profile.png](../../demo-screenshots/07-student-profile.png) |
+
+## Failure Responses
+
+| Failure | Response |
+|---|---|
+| Render down | Switch to local Tomcat. |
+| Tomcat down | Use screenshots and explain setup. |
+| MySQL down | Show schema and servlet code. |
+| Login fails | Show login servlet and known setup risks. |
+| Job posting fails | Show `PostJobServlet`, `jobs` schema, and screenshot. |
+
+## Final Reminder
+
+Switch to backup quickly. Do not spend presentation time debugging live.
+

--- a/portfolio/07-final-presentation/FINAL_PRESENTATION_SCRIPT.md
+++ b/portfolio/07-final-presentation/FINAL_PRESENTATION_SCRIPT.md
@@ -1,0 +1,63 @@
+# Final Presentation Script
+
+Maximum time: 15 minutes.
+
+## 0:00-2:00 Project Story
+
+Hello, we are Team StudentBridge. Our project helps international students in South Korea find student-friendly part-time jobs and helps local employers reach nearby student workers.
+
+The problem is that job information is scattered across many places, and students often do not know which jobs fit their schedule, language ability, location, or student status. Employers also do not have a focused way to reach international students.
+
+Our MVP is a web platform with a clear homepage, job search, registration and login, student profile support, employer dashboard, employer job posting, and MySQL-backed job data.
+
+## 2:00-7:00 Live MVP Demo
+
+1. Open <https://studentbridge-6jn2.onrender.com> or local Tomcat.
+2. Show the homepage and navigation.
+3. Open Jobs and show job search/filtering.
+4. Open Register and explain Student/Employer account types.
+5. Open Login and explain servlet authentication.
+6. Show student profile screenshot or page.
+7. Show employer dashboard and post-job flow.
+8. Explain that jobs are stored in MySQL when the database is configured.
+
+Key line: The demo shows the working marketplace structure: job search, accounts, employer posting, student application support, and documented limitations.
+
+## 7:00-9:00 Semester Journey
+
+At the start, StudentBridge was a broad idea about helping students find work. During the semester, we narrowed it into a practical MVP: a job platform with student and employer roles.
+
+We created user stories, architecture docs, setup guides, weekly sprint packets, testing notes, AI ownership documentation, and screenshots. The project moved from planning to frontend pages, then servlet/database integration, then deployment and final handoff.
+
+## 9:00-11:00 QA And Engineering Evidence
+
+Our QA evidence is in the portfolio. We tested the core pages, prepared screenshots, documented compile and frontend syntax checks, and wrote down known bugs.
+
+The most important limitations are:
+
+- Application submission depends on a logged-in student and profile/CV data.
+- Password security needs hashing before real users.
+- Database and deployment need correct environment variables.
+- We need final rehearsal before presentation.
+
+We chose to document these honestly rather than hide them.
+
+## 11:00-12:00 AI Use And Code Ownership
+
+AI helped us draft and organize some code, documentation, setup notes, and final portfolio materials. But the team is responsible for reviewing, testing, explaining, and debugging the work.
+
+Each member has an ownership area: backend/database, frontend job search, login/job integration, documentation, and QA.
+
+## 12:00-15:00 Technical Defense
+
+We are ready to answer questions about:
+
+- the Java Servlet flow,
+- how the database connection works,
+- how jobs are loaded and posted,
+- what the frontend pages do,
+- what is incomplete,
+- what AI helped with,
+- and what we would improve next.
+
+If a live demo problem happens, we will switch to screenshots and the backup demo plan.

--- a/portfolio/07-final-presentation/TECHNICAL_DEFENSE_PREP.md
+++ b/portfolio/07-final-presentation/TECHNICAL_DEFENSE_PREP.md
@@ -1,0 +1,41 @@
+# Technical Defense Prep
+
+## Questions The Team Should Be Ready For
+
+| Question | Strong answer |
+|---|---|
+| What problem does StudentBridge solve? | It helps international students in South Korea find student-friendly part-time jobs and helps employers reach them. |
+| What is the final MVP? | Homepage, job search, register/login, student profile, employer dashboard, post-job flow, MySQL schema, and deployment docs. |
+| What does the frontend use? | Plain HTML, CSS, and JavaScript. |
+| What does the backend use? | Java Servlets running on Tomcat. |
+| What database do you use? | MySQL, accessed through JDBC. |
+| How are jobs loaded? | `JobServlet` reads rows from the `jobs` table and returns JSON. |
+| How do employers post jobs? | `PostJobServlet` validates employer session data and inserts a job into MySQL. |
+| How does login work? | `LoginServlet` checks email/password and creates servlet session values. |
+| What is incomplete? | Password hashing, full accessibility audit, and stronger exact PR/issue evidence. |
+| What did AI help with? | Drafting, debugging, documentation organization, and portfolio structure. Humans remain responsible for testing and explaining. |
+
+## Ownership Areas
+
+| Student | Explain this area |
+|---|---|
+| Mezbah Uddin | `DBConnection`, deployment variables, homepage, backend setup. |
+| Sami Ul Alim | Job search UI and frontend filtering/display. |
+| Ali Mohamad Ashraf | Login flow and job page integration. |
+| Guramg Roman | Documentation, sprint packet evidence, portfolio organization. |
+| Dipesh Chaulagain | QA checklist, test evidence, demo validation. |
+
+## Honest Unknown Answer Template
+
+If we do not know something:
+
+> I do not want to guess. What I can explain is the part I worked on: [area]. The current risk is documented in the portfolio, and our next step would be [specific next step].
+
+## High-Risk Questions
+
+| Risk question | Answer direction |
+|---|---|
+| Why are passwords plain text? | It is a known demo limitation. Before real users, we would add hashing such as BCrypt and update login tests. |
+| What does application submission require? | A logged-in Student session, an existing job, and a student profile with a CV link. |
+| What if Render fails? | We have local Tomcat and screenshot backup. |
+| Can every member explain the code? | Every member owns at least one area listed in the individual portfolios. |

--- a/portfolio/07-final-presentation/slides/README.md
+++ b/portfolio/07-final-presentation/slides/README.md
@@ -1,0 +1,14 @@
+# Slides
+
+Slides are optional for the final presentation. If the team uses slides, add either:
+
+- editable slide link,
+- PDF export,
+- or exported images.
+
+The presentation can also be delivered directly from:
+
+- [Final presentation script](../FINAL_PRESENTATION_SCRIPT.md)
+- [Final MVP demo](../../04-final-product/FINAL_MVP_DEMO.md)
+- [Backup demo](../BACKUP_DEMO.md)
+

--- a/portfolio/08-individual-portfolios/ALI_MOHAMAD_ASHRAF.md
+++ b/portfolio/08-individual-portfolios/ALI_MOHAMAD_ASHRAF.md
@@ -1,0 +1,42 @@
+# Ali Mohamad Ashraf Individual Portfolio
+
+## Role
+
+Login flow, job page support, and frontend/backend integration support.
+
+## Main Responsibilities
+
+- Supported login and account-related behavior.
+- Helped connect job page work with backend expectations.
+- Shared ownership of the student/employer platform flow.
+
+## Strongest Contributions
+
+| Contribution | Evidence |
+|---|---|
+| Login page | [../../frontend/login.html](../../frontend/login.html) |
+| Login servlet | [../../Backend/LoginServlet.java](../../Backend/LoginServlet.java) |
+| Logout servlet | [../../Backend/LogoutServlet.java](../../Backend/LogoutServlet.java) |
+| Job servlet | [../../Backend/JobServlet.java](../../Backend/JobServlet.java) |
+| Login screenshot | [../../demo-screenshots/02-login.png](../../demo-screenshots/02-login.png) |
+
+## Technical Ownership Area
+
+I can explain how login collects credentials, how the servlet validates a user, and how session data supports the role-aware flow.
+
+## One Possible Failure
+
+If a user is not in the database or the database connection fails, login cannot succeed. The workaround is to seed demo users and verify MySQL before presenting.
+
+## AI Use
+
+AI helped with code examples and documentation organization. I am responsible for checking the flow, understanding the servlet behavior, and explaining limitations honestly.
+
+## Reflection
+
+I learned how login is more than a form: it depends on database schema, servlet routing, sessions, and redirects. I am proud of supporting the account flow. I should have captured more test evidence earlier. Next, I would add stronger validation and password hashing.
+
+## Skill To Continue Developing
+
+Authentication flow design and backend/frontend integration.
+

--- a/portfolio/08-individual-portfolios/DIPESH_CHAULAGAIN.md
+++ b/portfolio/08-individual-portfolios/DIPESH_CHAULAGAIN.md
@@ -1,0 +1,41 @@
+# Dipesh Chaulagain Individual Portfolio
+
+## Role
+
+Testing, QA support, and validation evidence.
+
+## Main Responsibilities
+
+- Supported QA planning and demo validation.
+- Helped identify bugs and limitations.
+- Helped keep the final demo realistic and testable.
+
+## Strongest Contributions
+
+| Contribution | Evidence |
+|---|---|
+| Testing notes | [../../docs/TESTING_NOTES.md](../../docs/TESTING_NOTES.md) |
+| QA report | [../05-qa-and-stabilization/QA_REPORT.md](../05-qa-and-stabilization/QA_REPORT.md) |
+| Bugs and limitations | [../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md](../05-qa-and-stabilization/BUGS_AND_LIMITATIONS.md) |
+| Demo screenshots | [../../demo-screenshots](../../demo-screenshots) |
+
+## Technical Ownership Area
+
+I can explain the manual QA checklist, how the team validates the main flow, and which limitations affect the final demo.
+
+## One Possible Failure
+
+The demo can fail if the database or deployment environment is not ready. The backup is to use local Tomcat, screenshots, and documented limitations.
+
+## AI Use
+
+AI helped draft QA structure and final portfolio text. I am responsible for checking the flows, documenting real results, and not hiding bugs.
+
+## Reflection
+
+I learned that QA is not only finding bugs; it is also protecting the presentation from surprises. I am proud of helping make limitations visible. I should have captured more screenshots and test results earlier. Next, I would create repeatable automated smoke tests.
+
+## Skill To Continue Developing
+
+Quality assurance, manual testing, and test automation.
+

--- a/portfolio/08-individual-portfolios/GURAMG_ROMAN.md
+++ b/portfolio/08-individual-portfolios/GURAMG_ROMAN.md
@@ -1,0 +1,41 @@
+# Guramg Roman Individual Portfolio
+
+## Role
+
+Documentation, sprint evidence, and project history support.
+
+## Main Responsibilities
+
+- Helped organize sprint evidence.
+- Supported documentation and portfolio material.
+- Helped keep project decisions and progress understandable.
+
+## Strongest Contributions
+
+| Contribution | Evidence |
+|---|---|
+| Documentation folder | [../../docs](../../docs) |
+| Sprint packets | [../../docs/Sprint-packets](../../docs/Sprint-packets) |
+| Team roles | [../../docs/TEAM_ROLES.md](../../docs/TEAM_ROLES.md) |
+| Semester journey | [../02-semester-journey/SEMESTER_JOURNEY.md](../02-semester-journey/SEMESTER_JOURNEY.md) |
+
+## Technical Ownership Area
+
+I can explain how the documentation proves the project history: project overview, architecture, sprint packets, QA notes, AI audit, and final portfolio.
+
+## One Possible Failure
+
+If evidence is not linked, the professor may not count the work. The fix is to connect every major claim to a file, issue, PR, screenshot, or demo artifact.
+
+## AI Use
+
+AI helped organize documentation and portfolio language. I am responsible for verifying that links are real and that the project history is honest.
+
+## Reflection
+
+I learned that documentation is part of engineering because it lets another person understand and trust the project. I am proud of supporting project clarity. I should have kept evidence links updated every week. Next, I would maintain a cleaner evidence checklist during each sprint.
+
+## Skill To Continue Developing
+
+Technical writing and evidence-based project management.
+

--- a/portfolio/08-individual-portfolios/MEZBAH_UDDIN.md
+++ b/portfolio/08-individual-portfolios/MEZBAH_UDDIN.md
@@ -1,0 +1,43 @@
+# Mezbah Uddin Individual Portfolio
+
+## Role
+
+Backend, database connection, homepage support, deployment support, and final portfolio implementation.
+
+## Main Responsibilities
+
+- Helped build and maintain backend servlet/database flow.
+- Worked on homepage and shared navigation polish.
+- Helped configure MySQL and deployment-related documentation.
+- Organized final portfolio evidence.
+
+## Strongest Contributions
+
+| Contribution | Evidence |
+|---|---|
+| Database connection setup | [../../Backend/DBConnection.java](../../Backend/DBConnection.java) |
+| Registration backend support | [../../Backend/RegisterServlet.java](../../Backend/RegisterServlet.java) |
+| Homepage and navigation | [../../index.html](../../index.html), [../../frontend/style.css](../../frontend/style.css) |
+| Deployment configuration | [../../render.yaml](../../render.yaml), [../../docs/DEPLOY_RENDER.md](../../docs/DEPLOY_RENDER.md) |
+| Final portfolio package | [../README.md](../README.md) |
+
+## Technical Ownership Area
+
+I can explain how `DBConnection` builds the JDBC connection using environment variables or local defaults, and how servlet files call the database during register, login, job loading, and job posting flows.
+
+## One Possible Failure
+
+If `DB_URL`, `DB_USER`, or `DB_PASSWORD` are wrong, the servlets cannot connect to MySQL. The fix is to verify environment variables and test with a simple query.
+
+## AI Use
+
+AI helped with code organization, documentation, and final portfolio drafting. I am responsible for reviewing the output, testing the app, and explaining the backend/database flow.
+
+## Reflection
+
+I learned how frontend pages, Java Servlets, Tomcat, MySQL, and deployment configuration fit together in a complete capstone project. I am proud that the project became a real platform structure instead of only static pages. I should have collected stronger PR and issue evidence earlier. Next, I would improve password security and complete the application submission flow.
+
+## Skill To Continue Developing
+
+Backend deployment and secure database-backed web applications.
+

--- a/portfolio/08-individual-portfolios/SAMI_UL_ALIM.md
+++ b/portfolio/08-individual-portfolios/SAMI_UL_ALIM.md
@@ -1,0 +1,41 @@
+# Sami Ul Alim Individual Portfolio
+
+## Role
+
+Frontend pages and job search support.
+
+## Main Responsibilities
+
+- Helped with job search user experience.
+- Supported frontend page structure and visual behavior.
+- Contributed to the student-facing product flow.
+
+## Strongest Contributions
+
+| Contribution | Evidence |
+|---|---|
+| Job search page | [../../frontend/jobsearch.html](../../frontend/jobsearch.html) |
+| Shared frontend styling | [../../frontend/style.css](../../frontend/style.css) |
+| Shared frontend behavior | [../../frontend/script.js](../../frontend/script.js) |
+| Job search screenshot | [../../demo-screenshots/04-jobsearch.png](../../demo-screenshots/04-jobsearch.png) |
+
+## Technical Ownership Area
+
+I can explain how the job search page presents job listings and how the frontend connects the student to the main product flow.
+
+## One Possible Failure
+
+If the backend job endpoint or database is unavailable, job content may not load as expected. The backup is to show screenshots and explain the schema and servlet.
+
+## AI Use
+
+AI helped with UI organization and documentation language. I remain responsible for understanding the frontend behavior and explaining how the page supports the MVP.
+
+## Reflection
+
+I learned how important a clear frontend flow is for a capstone demo. I am proud of helping make job search visible and understandable. I should have added more direct evidence links earlier. Next, I would improve filtering, empty states, and mobile polish.
+
+## Skill To Continue Developing
+
+Frontend engineering and user-centered interface design.
+

--- a/portfolio/README.md
+++ b/portfolio/README.md
@@ -1,0 +1,74 @@
+# StudentBridge Final Portfolio
+
+## Team
+
+| Item | Details |
+|---|---|
+| Team name | StudentBridge |
+| Project name | StudentBridge |
+| Course | Capstone Design, Spring 2026 |
+| Repository | <https://github.com/CapstoneDesign-Spring2026-UlsanCollege/StudentBridge> |
+| Current branch | `codex/org-sprint-deploy-final` |
+| Deployed app | <https://studentbridge-6jn2.onrender.com> |
+| Local demo path | <http://localhost:8080/StudentBridge/> |
+
+## Target User And Problem
+
+StudentBridge is built for international students in South Korea who need part-time jobs but face scattered job information, unclear requirements, language barriers, and uncertainty about student-friendly work. It also helps local employers reach student workers near universities.
+
+## Final MVP Summary
+
+The final MVP presents a student-friendly job platform with a homepage, searchable job listings, registration/login, role-aware student and employer flows, employer job posting, student applications with CV-link requirement, employer application review, messaging/notification support, student profile pages, MySQL-backed storage, and deployment support for Render. The team documents remaining limitations honestly, especially around security hardening, final accessibility review, and production readiness.
+
+## Portfolio Navigation
+
+| Section | Purpose |
+|---|---|
+| [Project Overview](01-project-overview/PROJECT_SUMMARY.md) | Project summary, MVP scope, and scope decisions. |
+| [Final MVP Scope](01-project-overview/FINAL_MVP_SCOPE.md) | Final core flow, included features, limitations, and excluded work. |
+| [Semester Journey](02-semester-journey/SEMESTER_JOURNEY.md) | Week-by-week and sprint-by-sprint history. |
+| [Weekly Files](02-semester-journey/weekly-sprints/WEEK_01.md) | Weekly evidence files for Week 1 through Week 16. |
+| [Sprint Summaries](02-semester-journey/sprint-summaries/SPRINT_01.md) | Sprint 1, Sprint 2, Sprint 3, Sprint 4, and final sprint summaries. |
+| [Design And Planning](03-design-and-planning/README.md) | Proposal, planning, architecture, user story, design, and roadmap evidence. |
+| [Final Product](04-final-product/FINAL_MVP_DEMO.md) | Demo flow, setup guide, final architecture, deployment, and screenshots. |
+| [QA And Stabilization](05-qa-and-stabilization/QA_REPORT.md) | Manual QA, validation notes, bugs, limitations, and evidence links. |
+| [AI And Code Ownership](06-ai-and-code-ownership/AI_USE_SUMMARY.md) | AI use, human review, ownership map, and risk areas. |
+| [Final Presentation](07-final-presentation/FINAL_PRESENTATION_SCRIPT.md) | 15-minute script, technical defense prep, and backup demo plan. |
+| [Individual Portfolios](08-individual-portfolios/MEZBAH_UDDIN.md) | Individual pages for each team member. |
+
+## Individual Portfolio Pages
+
+| Student | Page |
+|---|---|
+| Mezbah Uddin | [MEZBAH_UDDIN.md](08-individual-portfolios/MEZBAH_UDDIN.md) |
+| Sami Ul Alim | [SAMI_UL_ALIM.md](08-individual-portfolios/SAMI_UL_ALIM.md) |
+| Ali Mohamad Ashraf | [ALI_MOHAMAD_ASHRAF.md](08-individual-portfolios/ALI_MOHAMAD_ASHRAF.md) |
+| Guramg Roman | [GURAMG_ROMAN.md](08-individual-portfolios/GURAMG_ROMAN.md) |
+| Dipesh Chaulagain | [DIPESH_CHAULAGAIN.md](08-individual-portfolios/DIPESH_CHAULAGAIN.md) |
+
+## Strongest Evidence Links
+
+| Evidence | Link |
+|---|---|
+| Root project README | [../README.md](../README.md) |
+| Architecture docs | [../docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md) |
+| Setup guide | [../docs/SETUP_GUIDE.md](../docs/SETUP_GUIDE.md) |
+| Demo plan | [../docs/DEMO_PLAN.md](../docs/DEMO_PLAN.md) |
+| Testing notes | [../docs/TESTING_NOTES.md](../docs/TESTING_NOTES.md) |
+| AI ownership audit | [../docs/AI_CODE_OWNERSHIP_AUDIT.md](../docs/AI_CODE_OWNERSHIP_AUDIT.md) |
+| Screenshots | [../demo-screenshots](../demo-screenshots) |
+| Database schema | [../database_schema.sql](../database_schema.sql) |
+| Render deployment guide | [../docs/DEPLOY_RENDER.md](../docs/DEPLOY_RENDER.md) |
+
+## Final Readiness Checklist
+
+- [x] Portfolio folder exists.
+- [x] Portfolio front door exists.
+- [x] Required numbered folders exist.
+- [x] Week 1 through Week 16 files exist.
+- [x] Sprint summaries exist.
+- [x] Final MVP scope is documented.
+- [x] Setup, architecture, deployment, QA, AI use, and presentation files exist.
+- [x] Individual portfolio pages exist.
+- [ ] Team should do final live demo rehearsal before Wednesday, June 17, 2026 at 8:00 AM.
+- [ ] Team should add exact PR, issue, or screenshot links where available.


### PR DESCRIPTION
## Summary
- Add the required final portfolio folder structure for the Spring 2026 capstone handoff.
- Add final MVP scope, semester journey, 16 weekly files, 5 sprint summaries, design/planning indexes, final product docs, QA/bugs, AI/code ownership, presentation prep, and individual portfolio pages.
- Link existing evidence from docs, frontend, backend, database schema, deployment files, and demo screenshots.

## Changes
- Created `portfolio/README.md` as the professor-facing front door.
- Added all required numbered portfolio sections from `01-project-overview` through `08-individual-portfolios`.
- Updated root `README.md` to link to the final portfolio and replace old demo TODOs with available screenshot evidence.

## How Tested
- [x] Checked required portfolio files exist.
- [x] Ran Markdown link audit across portfolio and root README: 56 files checked, no broken local links.
- [x] Ran backend compile check with Servlet/MySQL jars.
- [x] Ran frontend syntax checks for `script.js`, `platform.js`, `runtime-config.js`, and `i18n.js`.

## AI Use Note
- AI helped organize and draft the final portfolio package from existing repository evidence and the professor checklist.
- I reviewed the generated structure, corrected stale final-MVP wording against current `main`, and verified links/checks.
- The portfolio documents remaining risks honestly: password hashing, demo data setup, accessibility review, and final rehearsal.

## Risk / Rollback
- Risk: individual pages may need teammate-specific edits for exact contribution wording or PR links.
- Rollback plan: revert this single documentation commit if needed.

## Checklist
- [x] Branch used instead of direct work on `main`.
- [x] Documentation updated.
- [x] No secrets or private data intentionally added.
- [x] Portfolio front door links all major sections.